### PR TITLE
Support for escaping insert mode with Ctrl+C

### DIFF
--- a/addons/godot-vim/godot-vim.gd
+++ b/addons/godot-vim/godot-vim.gd
@@ -141,7 +141,8 @@ var command_keys_white_list : Dictionary = {
     "Ctrl+D": 1,
     "Ctrl+O": 1,
     "Ctrl+I": 1,
-    "Ctrl+R": 1
+    "Ctrl+R": 1,
+    "Ctrl+C": 1
 }
 
 
@@ -1420,7 +1421,7 @@ class CommandDispatcher:
 
         vim.macro_manager.push_key(key)
 
-        if key_code == "Escape":
+        if key_code == "Escape" or key_code == "Ctrl+C":
             input_state.clear()
             vim.macro_manager.on_command_processed({}, vim.current.insert_mode)  # From insert mode to normal mode, this marks the end of an edit command
             vim.current.enter_normal_mode()


### PR DESCRIPTION
Allow to use `Ctrl+C` to escape from insert mode.
Not sure if this is less common then `Ctrl+[` or `Escape`. But I got used to this in VimCode so I want to share it with you.