### PR TITLE
Fix/unfocused errors thrown

### DIFF
--- a/addons/godot-vim/godot-vim.gd
+++ b/addons/godot-vim/godot-vim.gd
@@ -172,7 +172,7 @@ func _input(event) -> void:
     var key = event as InputEventKey
 
     # Don't process when not a key action
-    if key == null or !key.is_pressed() or not the_ed.has_focus():
+    if key == null or !key.is_pressed() or not the_ed or not the_ed.has_focus():
         return
 
     if key.get_keycode_with_modifiers() == KEY_NONE and key.unicode == CODE_MACRO_PLAY_END:

--- a/addons/godot-vim/godot-vim.gd
+++ b/addons/godot-vim/godot-vim.gd
@@ -1405,7 +1405,7 @@ class EditorAdaptor:
         return Position.new(result.y, result.x)
 
     func has_focus() -> bool:
-        return code_editor.has_focus()
+        return weakref(code_editor).get_ref() and code_editor.has_focus()
 
 
 class CommandDispatcher:


### PR DESCRIPTION
Resolve a bug where the editor can be null or even freed

Bug results in an error per key stroke.
  Ex: when editing attributes in the Inspector